### PR TITLE
Update local-setup.sh

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -33,6 +33,11 @@ This is usually caused by model detection issues:
 * **Distro Compatibility Issues**:
   The DAMX project is officially tested and supported on **Ubuntu only**. Other Linux distributions might introduce kernel or library incompatibilities, leading to missing features in the GUI.
 
+  For **Arch-based distributions**, make sure the following packages are installed:
+
+  ```bash
+  sudo pacman -S linux-headers clang llvm lld
+  ```
 ---
 
 ### 🛑 It Shows "Unknown Model" and My Model Isn’t in the Compatibility List

--- a/scripts/local-setup.sh
+++ b/scripts/local-setup.sh
@@ -186,9 +186,9 @@ install_drivers() {
   fi
 
   # Build and install drivers
-  make clean
-  make
-  make install
+make clean
+make CC=clang LD=ld.lld
+sudo make CC=clang LD=ld.lld install
 
   if [ $? -eq 0 ]; then
     echo -e "${GREEN}Linuwu-Sense drivers installed successfully!${NC}"


### PR DESCRIPTION
 explicitly use Clang as the compiler and
LLD as the linker.

Tried on ANV15-51.
Linux  6.16.7-2-cachyos #1 SMP PREEMPT_DYNAMIC Sat,  x86_64 GNU/Linux
