### PR TITLE
Fixed issue with writing of forced value to modprobe config

### DIFF
--- a/DivAcerManagerMax/InternalsManager.axaml.cs
+++ b/DivAcerManagerMax/InternalsManager.axaml.cs
@@ -30,6 +30,7 @@ public partial class InternalsManager : Window
             "enable_all" => 3,
             _ => 0 // Default to "No Parameter" for empty string or unknown values
         };
+        ForceParameterPermanentlyComboBox.SelectionChanged += ForceParameterPermanently_OnSelectionChanged;
     }
 
     private void DevModeSwitch_OnClick(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
There is an issue which prevents to update linuwu-sense.conf. ForceParameterPermanently_OnSelectionChanged is not executed.

My idea to assign event handler after initialisation to avoid usless updates. So it is because I didn't use axaml file 