### PR TITLE
Fix: Target AT Translated keyboard for Nitro button and prevent GUI spam

### DIFF
--- a/scripts/MapNitroButton.sh
+++ b/scripts/MapNitroButton.sh
@@ -1,58 +1,21 @@
 #!/bin/bash
 
-# Function to set up device permissions
-setup_permissions() {
-    echo "Setting up permissions..."
-    
-    # Add user to input group if not already
-    if ! groups | grep -q '\binput\b'; then
-        echo "Adding user $USER to 'input' group..."
-        usermod -a -G input $USER
-        echo "Note: You'll need to log out and back in for group changes to take effect."
-    fi
-    
-    # Create udev rule if needed
-    UDEV_RULE="/etc/udev/rules.d/99-input.rules"
-    if [ ! -f "$UDEV_RULE" ] || ! grep -q 'MODE="0660"' "$UDEV_RULE"; then
-        echo "Creating udev rules file..."
-        echo 'KERNEL=="event*", SUBSYSTEM=="input", MODE="0660", GROUP="input"' > /tmp/input.rules
-        mv /tmp/input.rules "$UDEV_RULE"
-        chmod 644 "$UDEV_RULE"
-        udevadm control --reload-rules
-        udevadm trigger
-        echo "Permissions rules updated."
-    fi
-    
-    echo "Permission setup complete."
-}
-
-# Find keyboard device
-DEVICE=$(grep -A 5 -B 5 "keyboard\|Keyboard" /proc/bus/input/devices | grep -m 1 "event" | sed 's/.*event\([0-9]\+\).*/\/dev\/input\/event\1/')
+# FIX 1: Target the internal motherboard keyboard directly (AT Translated) instead of generic "keyboard"
+DEVICE=$(grep -A 5 -B 5 "AT Translated Set 2 keyboard" /proc/bus/input/devices | grep -m 1 "event" | sed 's/.*event\([0-9]\+\).*/\/dev\/input\/event\1/')
 
 if [ -z "$DEVICE" ]; then
     echo "Error: Could not find keyboard device."
     exit 1
 fi
 
-# Check if we're root (sudo)
-if [ "$(id -u)" -eq 0 ]; then
-    # Running as root - perform setup then re-exec as normal user
-    setup_permissions
-    echo "Re-launching as normal user..."
-    exec sudo -u $SUDO_USER "$0"
-    exit 0
-fi
+echo "Monitoring Nitro button (code 425) on $DEVICE..." #require sudo
 
-# Check permissions
-if [ ! -r "$DEVICE" ]; then
-    echo "Error: Cannot read $DEVICE (permission denied)."
-    echo "Please run this script with sudo to set up permissions:"
-    echo "  sudo $0"
-    exit 1
-fi
-
-# Main functionality
-echo "Monitoring keyboard events on $DEVICE"
-evtest "$DEVICE" | grep --line-buffered "code 425.*value 1" | while read -r line; do
-    DAMX &
+# FIX 2: Run evtest with sudo, but execute GUI as normal user, added spam protection
+sudo evtest "$DEVICE" | grep --line-buffered "code 425.*value 1" | while read -r line; do
+    
+    if ! pgrep -x "DivAcerManagerMax" > /dev/null && ! pgrep -x "DAMX" > /dev/null; then
+        DAMX &
+    else
+        echo "Interface is already running!"
+    fi
 done


### PR DESCRIPTION
### What does this PR do?
Thıs PR fixes two major issues in the `MapNitroButton.sh` script that prevented the Nitro button from launching the application on modern Acer devices (tested on Acer Nitro 16).

### Root Causes & Fixes:
1. **Wrong Device Targeting:** The original script used a generic `grep "keyboard\|Keyboard"` which often targets external USB receivers or virtual Video Buses instead of the actual motherboard matrix where the Nitro button is hardwired. 
   * **Fix:** Narrowed the grep target specifically to `"AT Translated Set 2 keyboard"`.
2. **Privilege Drop / Spam Issue:** The script struggled with privilege drops and would spawn multiple instances of the application if the button was pressed consecutively.
   * **Fix:** Simplified the execution flow by only elevating `evtest` via `sudo` while keeping the rest in user-space. Added a `pgrep` check to prevent GUI spamming if the application is already running.

### Testing:
- Tested on acer nitro 16.
- The button now successfully intercepts `code 425` on the correct `event` node and launches the GUI without duplicate instances.
- I dont know if this works on other Acer devices so let me know if it doesnt work