### PR TITLE
Feature/smart nitro key

### DIFF
--- a/scripts/MapNitroButton.sh
+++ b/scripts/MapNitroButton.sh
@@ -1,58 +1,21 @@
 #!/bin/bash
 
-# Function to set up device permissions
-setup_permissions() {
-    echo "Setting up permissions..."
-    
-    # Add user to input group if not already
-    if ! groups | grep -q '\binput\b'; then
-        echo "Adding user $USER to 'input' group..."
-        usermod -a -G input $USER
-        echo "Note: You'll need to log out and back in for group changes to take effect."
-    fi
-    
-    # Create udev rule if needed
-    UDEV_RULE="/etc/udev/rules.d/99-input.rules"
-    if [ ! -f "$UDEV_RULE" ] || ! grep -q 'MODE="0660"' "$UDEV_RULE"; then
-        echo "Creating udev rules file..."
-        echo 'KERNEL=="event*", SUBSYSTEM=="input", MODE="0660", GROUP="input"' > /tmp/input.rules
-        mv /tmp/input.rules "$UDEV_RULE"
-        chmod 644 "$UDEV_RULE"
-        udevadm control --reload-rules
-        udevadm trigger
-        echo "Permissions rules updated."
-    fi
-    
-    echo "Permission setup complete."
-}
-
-# Find keyboard device
-DEVICE=$(grep -A 5 -B 5 "keyboard\|Keyboard" /proc/bus/input/devices | grep -m 1 "event" | sed 's/.*event\([0-9]\+\).*/\/dev\/input\/event\1/')
+# FIX 1: Target the internal motherboard keyboard directly (AT Translated) instead of generic "keyboard"
+DEVICE=$(grep -A 5 -B 5 "AT Translated Set 2 keyboard" /proc/bus/input/devices | grep -m 1 "event" | sed 's/.*event\([0-9]\+\).*/\/dev\/input\/event\1/')
 
 if [ -z "$DEVICE" ]; then
     echo "Error: Could not find keyboard device."
     exit 1
 fi
 
-# Check if we're root (sudo)
-if [ "$(id -u)" -eq 0 ]; then
-    # Running as root - perform setup then re-exec as normal user
-    setup_permissions
-    echo "Re-launching as normal user..."
-    exec sudo -u $SUDO_USER "$0"
-    exit 0
-fi
+echo "Monitoring Nitro button (code 425) on $DEVICE..." #require sudo
 
-# Check permissions
-if [ ! -r "$DEVICE" ]; then
-    echo "Error: Cannot read $DEVICE (permission denied)."
-    echo "Please run this script with sudo to set up permissions:"
-    echo "  sudo $0"
-    exit 1
-fi
-
-# Main functionality
-echo "Monitoring keyboard events on $DEVICE"
-evtest "$DEVICE" | grep --line-buffered "code 425.*value 1" | while read -r line; do
-    DAMX &
+# FIX 2: Run evtest with sudo, but execute GUI as normal user, added spam protection
+sudo evtest "$DEVICE" | grep --line-buffered "code 425.*value 1" | while read -r line; do
+    
+    if ! pgrep -x "DivAcerManagerMax" > /dev/null && ! pgrep -x "DAMX" > /dev/null; then
+        DAMX &
+    else
+        echo "Interface is already running!"
+    fi
 done

--- a/scripts/MapNitroButton.sh
+++ b/scripts/MapNitroButton.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
-# FIX 1: Target the internal motherboard keyboard directly (AT Translated) instead of generic "keyboard"
+# 1. Read conf file
+if [ -f "/etc/damx/nitro.conf" ]; then
+    source /etc/damx/nitro.conf
+else
+    # If can't read file, use default
+    NITRO_KEY=425
+fi
+
+# 2. Find device
 DEVICE=$(grep -A 5 -B 5 "AT Translated Set 2 keyboard" /proc/bus/input/devices | grep -m 1 "event" | sed 's/.*event\([0-9]\+\).*/\/dev\/input\/event\1/')
 
 if [ -z "$DEVICE" ]; then
@@ -8,11 +16,10 @@ if [ -z "$DEVICE" ]; then
     exit 1
 fi
 
-echo "Monitoring Nitro button (code 425) on $DEVICE..." #require sudo
+echo "Monitoring Nitro button (code $NITRO_KEY) on $DEVICE..." # require sudo
 
-# FIX 2: Run evtest with sudo, but execute GUI as normal user, added spam protection
-sudo evtest "$DEVICE" | grep --line-buffered "code 425.*value 1" | while read -r line; do
-    
+# 3. Start keylog
+sudo evtest "$DEVICE" | grep --line-buffered "code $NITRO_KEY.*value 1" | while read -r line; do
     if ! pgrep -x "DivAcerManagerMax" > /dev/null && ! pgrep -x "DAMX" > /dev/null; then
         DAMX &
     else

--- a/scripts/local-setup.sh
+++ b/scripts/local-setup.sh
@@ -300,6 +300,39 @@ EOL
   return 0
 }
 
+configure_nitro_button() {
+  echo -e "${YELLOW}Configuring Nitro Button Hardware Code...${NC}"
+
+  if ! command -v evtest &> /dev/null; then
+    echo -e "${BLUE}Installing evtest for hardware detection...${NC}"
+    apt-get update && apt-get install -y evtest
+  fi
+
+  DEVICE=$(grep -A 5 -B 5 "AT Translated Set 2 keyboard" /proc/bus/input/devices | grep -m 1 "event" | sed 's/.*event\([0-9]\+\).*/\/dev\/input\/event\1/')
+  
+  mkdir -p /etc/damx
+
+  if [ -z "$DEVICE" ]; then
+    echo -e "${RED}Error: Keyboard hardware not found! Using default Nitro code (425).${NC}"
+    echo "NITRO_KEY=425" > /etc/damx/nitro.conf
+    return 1
+  fi
+
+  echo -e "${GREEN}Keyboard detected at: $DEVICE${NC}"
+  echo -e "${YELLOW}>>> PLEASE PRESS YOUR NITRO (N) BUTTON NOW (Waiting 30 seconds)... <<<${NC}"
+
+  # NitroButton code 
+  CAPTURED_CODE=$(timeout 30 evtest "$DEVICE" | grep -m 1 "type 1 (EV_KEY).*value 1" | sed -n 's/.*code \([0-9]*\).*/\1/p')
+
+  if [ -n "$CAPTURED_CODE" ]; then
+    echo -e "${GREEN}Success! Nitro button code captured: ${CAPTURED_CODE}${NC}"
+    echo "NITRO_KEY=$CAPTURED_CODE" > /etc/damx/nitro.conf
+  else
+    echo -e "${RED}Timeout or no key detected. Falling back to default code (425).${NC}"
+    echo "NITRO_KEY=425" > /etc/damx/nitro.conf
+  fi
+}
+
 perform_install() {
   local skip_drivers=$1
   local is_update=$2
@@ -332,6 +365,9 @@ perform_install() {
 
   install_gui
   GUI_RESULT=$?
+
+  #Setup NitroButton shortcut
+  configure_nitro_button
 
   # Check if all installations were successful
   if [ $DRIVER_RESULT -eq 0 ] && [ $DAEMON_RESULT -eq 0 ] && [ $GUI_RESULT -eq 0 ]; then


### PR DESCRIPTION
**feat: Add auto-discovery for Nitro button hardware code while setup** 

Removed hardcoded 425 key code. The setup script now dynamically listens and captures the specific hardware code of the user's Nitro button and saves it to a config file. This ensures out-of-the-box compatibility with all Acer Nitro models. Thanks to @AntonioRocha17's feedback.