### PR TITLE
fix(daemon): use linuwu_sense module name in rmmod/modprobe + Predator log strings

### DIFF
--- a/DAMM-Daemon/DAMX-Daemon.py
+++ b/DAMM-Daemon/DAMX-Daemon.py
@@ -151,14 +151,14 @@ class DAMXManager:
 
         try:
             # Remove the module
-            subprocess.run(['sudo', 'rmmod', 'linuwu-sense'], check=True)
+            subprocess.run(['sudo', 'rmmod', 'linuwu_sense'], check=True)
             log.info("Successfully removed linuwu-sense module")
             
             # Wait a moment
             time.sleep(2)
             
             # Reload the module
-            subprocess.run(['sudo', 'modprobe', 'linuwu-sense', 'nitro_v4'], check=True)
+            subprocess.run(['sudo', 'modprobe', 'linuwu_sense', 'nitro_v4'], check=True)
             log.info("Successfully reloaded linuwu-sense module")
             
             # Wait a moment for module to initialize
@@ -176,48 +176,48 @@ class DAMXManager:
         
 
     def _force_model_predator(self):
-        """Restart linuwu-sense driver and DAMX daemon service with nitro_v4 parameter"""
-        log.info("Forcing model detection to Nitro by restarting drivers and daemon")
+        """Restart linuwu-sense driver and DAMX daemon service with predator_v4 parameter"""
+        log.info("Forcing model detection to Predator by restarting drivers and daemon")
 
         try:
             # Remove the module
-            subprocess.run(['sudo', 'rmmod', 'linuwu-sense'], check=True)
+            subprocess.run(['sudo', 'rmmod', 'linuwu_sense'], check=True)
             log.info("Successfully removed linuwu-sense module")
             
             # Wait a moment
             time.sleep(2)
             
             # Reload the module
-            subprocess.run(['sudo', 'modprobe', 'linuwu-sense', 'predator_v4'], check=True)
+            subprocess.run(['sudo', 'modprobe', 'linuwu_sense', 'predator_v4'], check=True)
             log.info("Successfully reloaded linuwu-sense module")
-            
+
             # Wait a moment for module to initialize
             time.sleep(3)
-            
+
             # Restart the daemon service
             log.info("Restarting DAMX daemon service (may produce an error)")
             subprocess.run(['sudo', 'systemctl', 'restart', 'damx-daemon.service'], check=True)
-            
+
             return True
-        
+
         except Exception as e:
-            log.error(f"Unexpected error while Forcing Nitro Model: {e}")
+            log.error(f"Unexpected error while Forcing Predator Model: {e}")
             return False
-    
+
     def _force_enable_all(self):
         """Restart linuwu-sense driver and DAMX daemon service with enable_all parameter"""
         log.info("Forcing all features by restarting daemon and drivers with parameter enable_all")
 
         try:
             # Remove the module
-            subprocess.run(['sudo', 'rmmod', 'linuwu-sense'], check=True)
+            subprocess.run(['sudo', 'rmmod', 'linuwu_sense'], check=True)
             log.info("Successfully removed linuwu-sense module")
             
             # Wait a moment
             time.sleep(2)
             
             # Reload the module
-            subprocess.run(['sudo', 'modprobe', 'linuwu-sense', 'enable_all'], check=True)
+            subprocess.run(['sudo', 'modprobe', 'linuwu_sense', 'enable_all'], check=True)
             log.info("Successfully reloaded linuwu-sense module with enable_all parameter")
             
             # Wait a moment for module to initialize
@@ -324,14 +324,14 @@ class DAMXManager:
         
         try:
             # Remove the module
-            subprocess.run(['sudo', 'rmmod', 'linuwu-sense'], check=True)
+            subprocess.run(['sudo', 'rmmod', 'linuwu_sense'], check=True)
             log.info("Successfully removed linuwu-sense module")
             
             # Wait a moment
             time.sleep(2)
             
             # Reload the module
-            subprocess.run(['sudo', 'modprobe', 'linuwu-sense'], check=True)
+            subprocess.run(['sudo', 'modprobe', 'linuwu_sense'], check=True)
             log.info("Successfully reloaded linuwu-sense module")
             
             # Wait a moment for module to initialize


### PR DESCRIPTION
## Summary

Two bugs in `DAMM-Daemon/DAMX-Daemon.py` (daemon v0.4.6) that together strand the daemon in `UNKNOWN` mode when the first detection attempt fails for any reason.

### 1. Wrong module name in `rmmod`/`modprobe` calls

Every `subprocess.run` invocation that touches the kernel module uses `'linuwu-sense'` (hyphen) instead of `'linuwu_sense'` (underscore). The actual module name is the underscore form (`lsmod` and `/sys/module/linuwu_sense` confirm). Affected functions:

- `_restart_drivers_and_daemon` (lines 327, 334)
- `_force_model_nitro` (154, 161)
- `_force_model_predator` (184, 191)
- `_force_enable_all` (213, 220)

`rmmod linuwu-sense` returns non-zero, `subprocess.run(..., check=True)` raises, the except branch fires, the restart helper returns `False`. In the `__init__` retry loop this looks like:

```
ERROR - Unexpected error during restart (attempt 4): Command '['sudo', 'rmmod', 'linuwu-sense']' returned non-zero exit status 1.
ERROR - Failed to restart drivers (attempt 4), continuing with limited functionality
INFO  - Detected laptop type: UNKNOWN
INFO  - Base path:
INFO  - Available features:
```

The daemon then settles into "limited functionality" mode for the lifetime of the process even when `/sys/module/linuwu_sense` is fine, and the GUI's "Force Predator/Nitro/Enable-all" buttons silently fail to actually reload the driver.

`/etc/modprobe.d/linuwu-sense.conf` (the conf file, not a kernel module argument) deliberately keeps the hyphen — modprobe normalizes `-` ↔ `_` in module names, so that file still applies. The fix only touches the actual module-name args passed to `rmmod` / `modprobe`.

### 2. `_force_model_predator` copy-paste artifacts

The docstring, the entry log, and the exception log in `_force_model_predator` all reference "Nitro" where they should say "Predator" — pure copy-paste from `_force_model_nitro`. The actual `modprobe ... predator_v4` call was already correct; only the logging was misleading.

## Test plan

- [x] Verified all 8 `rmmod`/`modprobe` call sites use `linuwu_sense` after patch (AST scan)
- [x] Daemon now boots to `Detected laptop type: PREDATOR` on an Acer Predator Triton 300 SE PT316-51s (companion PR upstreams the matching DMI quirk to Div-Linuwu-Sense)
- [x] All 8 features detected: `backlight_timeout, battery_calibration, battery_limiter, boot_animation_sound, fan_speed, lcd_override, thermal_profile, usb_charging`