### PR TITLE
feat(predator): add PHN16-72 back logo/lightbar controls

### DIFF
--- a/DAMM-Daemon/DAMX-Daemon.py
+++ b/DAMM-Daemon/DAMX-Daemon.py
@@ -18,7 +18,7 @@ import traceback
 from pathlib import Path
 from enum import Enum
 from PowerSourceDetection import PowerSourceDetector 
-from typing import Dict, List, Tuple, Set
+from typing import Dict, List, Tuple, Set, Optional
 # from KeyboardMonitor import KeyboardMonitor
 
 # Constants
@@ -474,6 +474,12 @@ class DAMXManager:
             if os.path.exists(os.path.join(kb_base, "four_zone_mode")):
                 available.add("four_zone_mode")
 
+        # Check rear logo / back-lid lightbar support.
+        # This is exposed by patched PHN16-72 drivers as:
+        #   /sys/module/linuwu_sense/drivers/platform:acer-wmi/acer-wmi/back_logo/color
+        if self._get_back_logo_color_path():
+            available.add("back_logo")
+
         return available
 
     def _check_four_zone_kb(self) -> bool:
@@ -482,6 +488,18 @@ class DAMXManager:
             kb_path = "/sys/module/linuwu_sense/drivers/platform:acer-wmi/acer-wmi/four_zoned_kb"
             return os.path.exists(kb_path)
         return False
+
+    def _get_back_logo_color_path(self) -> Optional[str]:
+        """Return the sysfs path for the rear logo/lightbar color control if present."""
+        candidates = [
+            "/sys/module/linuwu_sense/drivers/platform:acer-wmi/acer-wmi/back_logo/color",
+        ]
+
+        for path in candidates:
+            if os.path.exists(path):
+                return path
+
+        return None
 
     def _read_file(self, path: str) -> str:
         """Read from a VFS file"""
@@ -758,6 +776,53 @@ class DAMXManager:
             value
         )
 
+
+    def get_back_logo_color(self) -> str:
+        """Get rear logo/lightbar RGB configuration: RRGGBB,brightness,enable."""
+        if "back_logo" not in self.available_features:
+            return ""
+
+        color_path = self._get_back_logo_color_path()
+        if not color_path:
+            return ""
+
+        return self._read_file(color_path)
+
+    def set_back_logo_color(self, color: str, brightness: int, enabled: bool) -> bool:
+        """Set rear logo/lightbar RGB configuration.
+
+        Args:
+            color: RGB hex value in RRGGBB format.
+            brightness: Brightness between 0 and 100.
+            enabled: True to power the lightbar/logo, False to disable it.
+        """
+        if "back_logo" not in self.available_features:
+            return False
+
+        normalized = str(color).strip().lstrip("#")
+        if len(normalized) != 6:
+            log.error(f"Invalid back logo color length: {color}. Must be RRGGBB.")
+            return False
+
+        try:
+            int(normalized, 16)
+        except ValueError:
+            log.error(f"Invalid back logo color: {color}. Must be hexadecimal RRGGBB.")
+            return False
+
+        if not (0 <= brightness <= 100):
+            log.error(f"Invalid back logo brightness. Must be between 0 and 100: {brightness}")
+            return False
+
+        color_path = self._get_back_logo_color_path()
+        if not color_path:
+            log.error("Back logo sysfs color path is not available")
+            return False
+
+        enable_value = 1 if enabled else 0
+        value = f"{normalized.upper()},{brightness},{enable_value}\n"
+        return self._write_file(color_path, value)
+
     def get_all_settings(self) -> Dict:
         """Get all DAMX-Daemon settings as a dictionary"""
         settings = {
@@ -813,6 +878,9 @@ class DAMXManager:
 
         if "four_zone_mode" in self.available_features:
             settings["four_zone_mode"] = self.get_four_zone_mode()
+
+        if "back_logo" in self.available_features:
+            settings["back_logo_color"] = self.get_back_logo_color()
 
         return settings
 
@@ -1157,6 +1225,28 @@ class DaemonServer:
                         "blue": blue
                     } if success else None,
                     "error": "Failed to set four-zone mode" if not success else None
+                }
+
+            elif command == "set_back_logo_color":
+                # Check if feature is available
+                if "back_logo" not in self.manager.available_features:
+                    return {
+                        "success": False,
+                        "error": "Back logo/lightbar control is not supported on this device"
+                    }
+
+                color = params.get("color", "FFFFFF")
+                brightness = params.get("brightness", 100)
+                enabled = params.get("enabled", True)
+                success = self.manager.set_back_logo_color(color, brightness, enabled)
+                return {
+                    "success": success,
+                    "data": {
+                        "color": color,
+                        "brightness": brightness,
+                        "enabled": enabled
+                    } if success else None,
+                    "error": "Failed to set back logo/lightbar color" if not success else None
                 }
 
             elif command == "get_supported_features":

--- a/DivAcerManagerMax/DAMXClient.cs
+++ b/DivAcerManagerMax/DAMXClient.cs
@@ -492,6 +492,32 @@ public class DAMXClient : IDisposable
         return response.RootElement.GetProperty("success").GetBoolean();
     }
 
+    /// <summary>
+    ///     Set rear logo / back-lid lightbar color.
+    /// </summary>
+    /// <param name="color">RGB hex value in RRGGBB format.</param>
+    /// <param name="brightness">Brightness 0-100.</param>
+    /// <param name="enabled">Enable or disable logo/lightbar power.</param>
+    /// <returns>True if successful</returns>
+    public async Task<bool> SetBackLogoColorAsync(string color, int brightness, bool enabled)
+    {
+        if (!IsFeatureAvailable("back_logo"))
+        {
+            Console.WriteLine("Back logo/lightbar control is not available on this device");
+            return false;
+        }
+
+        var parameters = new Dictionary<string, object>
+        {
+            { "color", color },
+            { "brightness", brightness },
+            { "enabled", enabled }
+        };
+
+        var response = await SendCommandAsync("set_back_logo_color", parameters);
+        return response.RootElement.GetProperty("success").GetBoolean();
+    }
+
     protected virtual void Dispose(bool disposing)
     {
         if (_disposed) return;
@@ -567,6 +593,8 @@ public class DAMXSettings
     [JsonPropertyName("per_zone_mode")] public string PerZoneMode { get; set; } = "";
 
     [JsonPropertyName("four_zone_mode")] public string FourZoneMode { get; set; } = "";
+
+    [JsonPropertyName("back_logo_color")] public string BackLogoColor { get; set; } = "";
 
     [JsonPropertyName("modprobe_parameter")]
     public string ModprobeParameter { get; set; } = "";

--- a/DivAcerManagerMax/MainWindow.axaml
+++ b/DivAcerManagerMax/MainWindow.axaml
@@ -496,6 +496,89 @@
                                 </StackPanel>
                             </Border>
 
+
+
+                            <!-- Back Logo / Lightbar -->
+                            <Border Classes="Card" x:Name="BackLogoControls">
+                                <StackPanel>
+                                    <TextBlock Text="Back Logo / Lightbar" Classes="SubHeader" />
+                                    <TextBlock Text="Rear display-lid logo/lightbar control. Static mode is firmware-backed; animated effects are software-driven and intentionally rate-limited."
+                                               Opacity="0.7" Margin="0 0 0 10" TextWrapping="Wrap" />
+
+                                    <CheckBox x:Name="BackLogoEnabledCheckBox"
+                                              Content="Enable rear logo/lightbar" IsChecked="True"
+                                              Margin="0 10" />
+
+                                    <Grid ColumnDefinitions="Auto,*,Auto" RowDefinitions="Auto,Auto,Auto,Auto" Margin="0 10">
+                                        <TextBlock Grid.Row="0" Grid.Column="0" Text="Color:"
+                                                   VerticalAlignment="Center" Width="90" />
+                                        <ColorPicker x:Name="BackLogoColorPicker"
+                                                     IsAlphaEnabled="True"
+                                                     HexInputAlphaPosition="Trailing"
+                                                     Color="#FFFFFFFF"
+                                                     VerticalAlignment="Top"
+                                                     HorizontalAlignment="Left"
+                                                     Height="54"
+                                                     Grid.Row="0"
+                                                     Grid.Column="1"
+                                                     Width="230" />
+
+                                        <TextBlock Grid.Row="1" Grid.Column="0" Text="Brightness:"
+                                                   VerticalAlignment="Center" Width="90" Margin="0 15 0 0" />
+                                        <Slider x:Name="BackLogoBrightnessSlider" Grid.Row="1" Grid.Column="1" Value="100"
+                                                Maximum="100" Minimum="0" IsSnapToTickEnabled="True" TickFrequency="1"
+                                                Margin="0 15 10 0" />
+                                        <TextBlock x:Name="BackLogoBrightnessText" Grid.Row="1" Grid.Column="2" Text="100%"
+                                                   VerticalAlignment="Center" Width="55" TextAlignment="Right" Margin="0 15 0 0" />
+
+                                        <TextBlock Grid.Row="2" Grid.Column="0" Text="Opacity:"
+                                                   VerticalAlignment="Center" Width="90" Margin="0 10 0 0" />
+                                        <Slider x:Name="BackLogoOpacitySlider" Grid.Row="2" Grid.Column="1" Value="100"
+                                                Maximum="100" Minimum="0" IsSnapToTickEnabled="True" TickFrequency="1"
+                                                Margin="0 10 10 0" />
+                                        <TextBlock x:Name="BackLogoOpacityText" Grid.Row="2" Grid.Column="2" Text="100%"
+                                                   VerticalAlignment="Center" Width="55" TextAlignment="Right" Margin="0 10 0 0" />
+
+                                        <TextBlock Grid.Row="3" Grid.Column="0" Text="Effect:"
+                                                   VerticalAlignment="Center" Width="90" Margin="0 12 0 0" />
+                                        <StackPanel Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="10" Margin="0 12 0 0">
+                                            <ComboBox x:Name="BackLogoEffectComboBox" SelectedIndex="0" Width="185">
+                                                <ComboBoxItem Content="Static" />
+                                                <ComboBoxItem Content="Rainbow Cycle" />
+                                                <ComboBoxItem Content="Breathing" />
+                                            </ComboBox>
+                                            <TextBlock Text="Speed" VerticalAlignment="Center" Margin="5 0" />
+                                            <Slider x:Name="BackLogoEffectSpeedSlider" Width="150" Value="5"
+                                                    Minimum="1" Maximum="10" TickFrequency="1" IsSnapToTickEnabled="True" />
+                                            <TextBlock x:Name="BackLogoEffectSpeedText" Text="5" VerticalAlignment="Center" Width="25" />
+                                        </StackPanel>
+                                    </Grid>
+
+                                    <TextBlock Text="Color presets" Classes="SubHeader" Margin="0 12 0 5" />
+                                    <WrapPanel Margin="0 0 0 10">
+                                        <Button x:Name="BackLogoPresetWhite" Content="White" Margin="0 4 6 4" />
+                                        <Button x:Name="BackLogoPresetIce" Content="Ice" Margin="0 4 6 4" />
+                                        <Button x:Name="BackLogoPresetCyan" Content="Cyan" Margin="0 4 6 4" />
+                                        <Button x:Name="BackLogoPresetBlue" Content="Blue" Margin="0 4 6 4" />
+                                        <Button x:Name="BackLogoPresetPurple" Content="Purple" Margin="0 4 6 4" />
+                                        <Button x:Name="BackLogoPresetPink" Content="Pink" Margin="0 4 6 4" />
+                                        <Button x:Name="BackLogoPresetRed" Content="Red" Margin="0 4 6 4" />
+                                        <Button x:Name="BackLogoPresetOrange" Content="Orange" Margin="0 4 6 4" />
+                                        <Button x:Name="BackLogoPresetYellow" Content="Yellow" Margin="0 4 6 4" />
+                                        <Button x:Name="BackLogoPresetGreen" Content="Green" Margin="0 4 6 4" />
+                                    </WrapPanel>
+
+                                    <TextBlock x:Name="BackLogoEffectiveText"
+                                               Text="Effective output: static color at 100% intensity"
+                                               Opacity="0.65" Margin="0 0 0 8" TextWrapping="Wrap" />
+
+                                    <StackPanel Orientation="Horizontal" Spacing="10">
+                                        <Button x:Name="ApplyBackLogoButton" Content="Apply Logo" Margin="0 5 0 0" />
+                                        <Button x:Name="StopBackLogoEffectButton" Content="Stop Effect" IsEnabled="False" Margin="0 5 0 0" />
+                                    </StackPanel>
+                                </StackPanel>
+                            </Border>
+
                             <!-- Backlight Timeout -->
                             <Border Classes="Card" x:Name="BacklightTimeoutControls">
                                 <StackPanel>

--- a/DivAcerManagerMax/MainWindow.axaml.cs
+++ b/DivAcerManagerMax/MainWindow.axaml.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -22,11 +23,14 @@ public partial class MainWindow : Window, INotifyPropertyChanged
     private const string DefaultZone2Color = "#ff5733";
     private const string DefaultZone3Color = "#33ff57";
     private const string DefaultZone4Color = "#ffff01";
+    private const string DefaultBackLogoColor = "#FFFFFF";
     private const int DirectionLeftToRight = 1;
     private const int DirectionRightToLeft = 2;
     private const string AppDataFolderName = "DivAcerManagerMax";
     private const string KeyboardZonePresetFileName = "keyboard-zone-colors.conf";
     private const string KeyboardLightingEffectPresetFileName = "keyboard-lighting-effect.conf";
+    private const int BackLogoMinEffectDelayMs = 250;
+    private const int BackLogoMaxEffectDelayMs = 1200;
 
     private static readonly string AppDataFolderPath =
         Path.Combine(
@@ -41,9 +45,25 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         Path.Combine(AppDataFolderPath, KeyboardLightingEffectPresetFileName);
 
     // UI Controls (will be bound via NameScope)
+    private Button _applyBackLogoButton;
     private Button _applyKeyboardColorsButton;
     private RadioButton _autoFanSpeedRadioButton;
     private CheckBox _backlightTimeoutCheckBox;
+    private int _backLogoBrightness = 100;
+    private Slider _backLogoBrightnessSlider;
+    private TextBlock _backLogoBrightnessText;
+    private ColorPicker _backLogoColorPicker;
+    private ComboBox _backLogoEffectComboBox;
+    private int _backLogoEffectSpeed = 5;
+    private Slider _backLogoEffectSpeedSlider;
+    private TextBlock _backLogoEffectSpeedText;
+    private CheckBox _backLogoEnabledCheckBox;
+    private int _backLogoOpacity = 100;
+    private Slider _backLogoOpacitySlider;
+    private TextBlock _backLogoOpacityText;
+    private TextBlock _backLogoEffectiveText;
+    private Button _stopBackLogoEffectButton;
+    private CancellationTokenSource? _backLogoEffectCts;
     private RadioButton _balancedProfileButton;
     private CheckBox _batteryLimitCheckBox;
     private CheckBox _bootAnimAndSoundCheckBox;
@@ -163,6 +183,20 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         _keyBrightnessText = nameScope.Find<TextBlock>("KeyBrightnessText");
         _applyKeyboardColorsButton = nameScope.Find<Button>("ApplyKeyboardColorsButton");
 
+        // Back logo / lightbar controls
+        _backLogoColorPicker = nameScope.Find<ColorPicker>("BackLogoColorPicker");
+        _backLogoBrightnessSlider = nameScope.Find<Slider>("BackLogoBrightnessSlider");
+        _backLogoBrightnessText = nameScope.Find<TextBlock>("BackLogoBrightnessText");
+        _backLogoOpacitySlider = nameScope.Find<Slider>("BackLogoOpacitySlider");
+        _backLogoOpacityText = nameScope.Find<TextBlock>("BackLogoOpacityText");
+        _backLogoEffectComboBox = nameScope.Find<ComboBox>("BackLogoEffectComboBox");
+        _backLogoEffectSpeedSlider = nameScope.Find<Slider>("BackLogoEffectSpeedSlider");
+        _backLogoEffectSpeedText = nameScope.Find<TextBlock>("BackLogoEffectSpeedText");
+        _backLogoEnabledCheckBox = nameScope.Find<CheckBox>("BackLogoEnabledCheckBox");
+        _backLogoEffectiveText = nameScope.Find<TextBlock>("BackLogoEffectiveText");
+        _applyBackLogoButton = nameScope.Find<Button>("ApplyBackLogoButton");
+        _stopBackLogoEffectButton = nameScope.Find<Button>("StopBackLogoEffectButton");
+
         // Lighting effects controls
         _lightingModeComboBox = nameScope.Find<ComboBox>("LightingModeComboBox");
         _lightingSpeedSlider = nameScope.Find<Slider>("LightingSpeedSlider");
@@ -229,6 +263,25 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         if (_keyBrightnessSlider != null) _keyBrightnessSlider.PropertyChanged += KeyboardBrightnessSlider_ValueChanged;
         if (_applyKeyboardColorsButton != null) _applyKeyboardColorsButton.Click += ApplyKeyboardColorsButton_Click;
 
+        // Back logo / lightbar handlers
+        if (_backLogoBrightnessSlider != null) _backLogoBrightnessSlider.PropertyChanged += BackLogoBrightnessSlider_ValueChanged;
+        if (_backLogoOpacitySlider != null) _backLogoOpacitySlider.PropertyChanged += BackLogoOpacitySlider_ValueChanged;
+        if (_backLogoEffectSpeedSlider != null) _backLogoEffectSpeedSlider.PropertyChanged += BackLogoEffectSpeedSlider_ValueChanged;
+        if (_backLogoEnabledCheckBox != null) _backLogoEnabledCheckBox.Click += BackLogoEnabledCheckBox_Click;
+        if (_applyBackLogoButton != null) _applyBackLogoButton.Click += ApplyBackLogoButton_Click;
+        if (_stopBackLogoEffectButton != null) _stopBackLogoEffectButton.Click += StopBackLogoEffectButton_Click;
+
+        AttachBackLogoPresetButton("BackLogoPresetWhite", "FFFFFF");
+        AttachBackLogoPresetButton("BackLogoPresetIce", "DFF8FF");
+        AttachBackLogoPresetButton("BackLogoPresetCyan", "00FFCC");
+        AttachBackLogoPresetButton("BackLogoPresetBlue", "0078FF");
+        AttachBackLogoPresetButton("BackLogoPresetPurple", "8A2BE2");
+        AttachBackLogoPresetButton("BackLogoPresetPink", "FF2DAA");
+        AttachBackLogoPresetButton("BackLogoPresetRed", "FF0000");
+        AttachBackLogoPresetButton("BackLogoPresetOrange", "FF7A00");
+        AttachBackLogoPresetButton("BackLogoPresetYellow", "FFD400");
+        AttachBackLogoPresetButton("BackLogoPresetGreen", "00FF66");
+
         // Lighting effects handlers
         if (_lightingSpeedSlider != null) _lightingSpeedSlider.PropertyChanged += LightingSpeedSlider_ValueChanged;
         if (_lightingEffectsApplyButton != null) _lightingEffectsApplyButton.Click += LightingEffectsApplyButton_Click;
@@ -277,7 +330,8 @@ public partial class MainWindow : Window, INotifyPropertyChanged
 
         var hasKeyboardFeatures = _client.IsFeatureAvailable("backlight_timeout") ||
                                   _client.IsFeatureAvailable("per_zone_mode") ||
-                                  _client.IsFeatureAvailable("four_zone_mode");
+                                  _client.IsFeatureAvailable("four_zone_mode") ||
+                                  _client.IsFeatureAvailable("back_logo");
 
         if (keyboardLightingTab != null)
             keyboardLightingTab.IsVisible = hasKeyboardFeatures;
@@ -287,6 +341,10 @@ public partial class MainWindow : Window, INotifyPropertyChanged
 
         if (keyboardEffectsPanel != null)
             keyboardEffectsPanel.IsVisible = _client.IsFeatureAvailable("four_zone_mode") || AppState.DevMode;
+
+        var backLogoControls = nameScope.Find<Border>("BackLogoControls");
+        if (backLogoControls != null)
+            backLogoControls.IsVisible = _client.IsFeatureAvailable("back_logo") || AppState.DevMode;
 
         if (usbChargingPanel != null)
             usbChargingPanel.IsVisible = _client.IsFeatureAvailable("usb_charging") || AppState.DevMode;
@@ -475,6 +533,7 @@ public partial class MainWindow : Window, INotifyPropertyChanged
             _manualFanSpeedRadioButton.IsChecked = isManualMode;
 
         ApplyKeyboardSettings();
+        ApplyBackLogoSettingsToUI();
 
         SetText(_keyBrightnessText, $"{_keyboardBrightness}%");
         SetText(_lightSpeedTextBlock, _lightingSpeed.ToString());
@@ -635,6 +694,26 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         // Mode 2 / Neon often reports 0,0,0. Do not overwrite the color picker with black for that.
         if (mode != 2 || red != 0 || green != 0 || blue != 0)
             SetColorPicker(_lightEffectColorPicker, $"{red:X2}{green:X2}{blue:X2}");
+    }
+
+
+    private void ApplyBackLogoSettingsToUI()
+    {
+        if (string.IsNullOrWhiteSpace(_settings.BackLogoColor))
+            return;
+
+        if (!TryParseBackLogoColor(
+                _settings.BackLogoColor,
+                out var color,
+                out var brightness,
+                out var enabled))
+            return;
+
+        SetColorPicker(_backLogoColorPicker, color);
+        SetBackLogoBrightness(brightness);
+        SetBackLogoOpacity(100);
+        SetCheckBox(_backLogoEnabledCheckBox, enabled);
+        UpdateBackLogoEffectiveText();
     }
 
     private async Task ShowMessageBox(string title, string message)
@@ -884,6 +963,184 @@ public partial class MainWindow : Window, INotifyPropertyChanged
             SetLightingSpeed(Convert.ToInt32(e.NewValue), false);
     }
 
+    private void BackLogoBrightnessSlider_ValueChanged(object sender, AvaloniaPropertyChangedEventArgs e)
+    {
+        if (e.Property == Slider.ValueProperty)
+            SetBackLogoBrightness(Convert.ToInt32(e.NewValue), false);
+    }
+
+    private void BackLogoOpacitySlider_ValueChanged(object sender, AvaloniaPropertyChangedEventArgs e)
+    {
+        if (e.Property == Slider.ValueProperty)
+            SetBackLogoOpacity(Convert.ToInt32(e.NewValue), false);
+    }
+
+    private void BackLogoEffectSpeedSlider_ValueChanged(object sender, AvaloniaPropertyChangedEventArgs e)
+    {
+        if (e.Property == Slider.ValueProperty)
+            SetBackLogoEffectSpeed(Convert.ToInt32(e.NewValue), false);
+    }
+
+    private void AttachBackLogoPresetButton(string buttonName, string rgbHex)
+    {
+        var nameScope = this.FindNameScope();
+        var button = nameScope.Find<Button>(buttonName);
+        if (button != null)
+        {
+            button.Click += (_, _) =>
+            {
+                SetColorPicker(_backLogoColorPicker, rgbHex);
+                UpdateBackLogoEffectiveText();
+            };
+        }
+    }
+
+    private async void ApplyBackLogoButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (!_isConnected || (!_client.IsFeatureAvailable("back_logo") && !AppState.DevMode))
+            return;
+
+        var effectIndex = _backLogoEffectComboBox?.SelectedIndex ?? 0;
+        if (effectIndex <= 0)
+        {
+            StopBackLogoEffect();
+            await ApplyBackLogoStaticAsync();
+            return;
+        }
+
+        StartBackLogoEffect(effectIndex);
+    }
+
+    private async void StopBackLogoEffectButton_Click(object sender, RoutedEventArgs e)
+    {
+        StopBackLogoEffect();
+        await ApplyBackLogoStaticAsync();
+    }
+
+    private async void BackLogoEnabledCheckBox_Click(object sender, RoutedEventArgs e)
+    {
+        if (!_isConnected || (!_client.IsFeatureAvailable("back_logo") && !AppState.DevMode))
+            return;
+
+        if (_backLogoEnabledCheckBox?.IsChecked == false)
+            StopBackLogoEffect();
+
+        await ApplyBackLogoStaticAsync();
+    }
+
+    private async Task ApplyBackLogoStaticAsync(Color? overrideColor = null, int? overrideBrightness = null, bool? overrideEnabled = null)
+    {
+        var color = overrideColor ?? _backLogoColorPicker?.Color ?? Color.Parse(DefaultBackLogoColor);
+        var enabled = overrideEnabled ?? (_backLogoEnabledCheckBox?.IsChecked ?? true);
+        var brightness = overrideBrightness ?? GetEffectiveBackLogoBrightness(color);
+
+        await _client.SetBackLogoColorAsync(
+            ToRgbHex(color),
+            brightness,
+            enabled
+        );
+
+        UpdateBackLogoEffectiveText(brightness);
+    }
+
+    private void StartBackLogoEffect(int effectIndex)
+    {
+        StopBackLogoEffect();
+
+        if (!_isConnected || (!_client.IsFeatureAvailable("back_logo") && !AppState.DevMode))
+            return;
+
+        _backLogoEffectCts = new CancellationTokenSource();
+        if (_stopBackLogoEffectButton != null)
+            _stopBackLogoEffectButton.IsEnabled = true;
+
+        _ = RunBackLogoEffectSafeAsync(effectIndex, _backLogoEffectCts.Token);
+    }
+
+    private async Task RunBackLogoEffectSafeAsync(int effectIndex, CancellationToken token)
+    {
+        try
+        {
+            switch (effectIndex)
+            {
+                case 1:
+                    await RunBackLogoRainbowCycleAsync(token);
+                    break;
+                case 2:
+                    await RunBackLogoBreathingAsync(token);
+                    break;
+                default:
+                    await ApplyBackLogoStaticAsync();
+                    break;
+            }
+        }
+        catch (TaskCanceledException)
+        {
+            // Expected when the user stops an effect.
+        }
+        catch (Exception ex)
+        {
+            await ShowMessageBox("Back Logo Effect Error", $"Failed to run logo effect: {ex.Message}");
+        }
+    }
+
+    private async Task RunBackLogoRainbowCycleAsync(CancellationToken token)
+    {
+        var colors = new[]
+        {
+            "FF0000", "FF7A00", "FFD400", "00FF66", "00FFCC", "0078FF", "8A2BE2", "FF2DAA"
+        };
+
+        while (!token.IsCancellationRequested)
+        {
+            foreach (var hex in colors)
+            {
+                token.ThrowIfCancellationRequested();
+                var color = Color.Parse($"#{hex}");
+                await _client.SetBackLogoColorAsync(hex, GetEffectiveBackLogoBrightness(color), true);
+                await Task.Delay(GetBackLogoEffectDelayMs(), token);
+            }
+        }
+    }
+
+    private async Task RunBackLogoBreathingAsync(CancellationToken token)
+    {
+        var color = _backLogoColorPicker?.Color ?? Color.Parse(DefaultBackLogoColor);
+        var hex = ToRgbHex(color);
+        var maxBrightness = Math.Max(1, GetEffectiveBackLogoBrightness(color));
+        var delay = Math.Max(80, GetBackLogoEffectDelayMs() / 8);
+
+        while (!token.IsCancellationRequested)
+        {
+            for (var level = 10; level <= 100; level += 10)
+            {
+                token.ThrowIfCancellationRequested();
+                await _client.SetBackLogoColorAsync(hex, Math.Max(1, maxBrightness * level / 100), true);
+                await Task.Delay(delay, token);
+            }
+
+            for (var level = 90; level >= 10; level -= 10)
+            {
+                token.ThrowIfCancellationRequested();
+                await _client.SetBackLogoColorAsync(hex, Math.Max(1, maxBrightness * level / 100), true);
+                await Task.Delay(delay, token);
+            }
+        }
+    }
+
+    private void StopBackLogoEffect()
+    {
+        if (_backLogoEffectCts == null)
+            return;
+
+        _backLogoEffectCts.Cancel();
+        _backLogoEffectCts.Dispose();
+        _backLogoEffectCts = null;
+
+        if (_stopBackLogoEffectButton != null)
+            _stopBackLogoEffectButton.IsEnabled = false;
+    }
+
     private async void LightingEffectsApplyButton_Click(object sender, RoutedEventArgs e)
     {
         if ((_isConnected && _settings.HasFourZoneKb) || AppState.DevMode)
@@ -978,6 +1235,67 @@ public partial class MainWindow : Window, INotifyPropertyChanged
         SetText(_lightSpeedTextBlock, speed.ToString());
     }
 
+    private void SetBackLogoBrightness(int brightness, bool updateSlider = true)
+    {
+        _backLogoBrightness = brightness;
+
+        if (updateSlider && _backLogoBrightnessSlider != null)
+            _backLogoBrightnessSlider.Value = brightness;
+
+        SetText(_backLogoBrightnessText, $"{brightness}%");
+    }
+
+    private void SetBackLogoOpacity(int opacity, bool updateSlider = true)
+    {
+        _backLogoOpacity = Math.Clamp(opacity, 0, 100);
+
+        if (updateSlider && _backLogoOpacitySlider != null)
+            _backLogoOpacitySlider.Value = _backLogoOpacity;
+
+        SetText(_backLogoOpacityText, $"{_backLogoOpacity}%");
+        UpdateBackLogoEffectiveText();
+    }
+
+    private void SetBackLogoEffectSpeed(int speed, bool updateSlider = true)
+    {
+        _backLogoEffectSpeed = Math.Clamp(speed, 1, 10);
+
+        if (updateSlider && _backLogoEffectSpeedSlider != null)
+            _backLogoEffectSpeedSlider.Value = _backLogoEffectSpeed;
+
+        SetText(_backLogoEffectSpeedText, _backLogoEffectSpeed.ToString());
+    }
+
+    private int GetEffectiveBackLogoBrightness(Color color)
+    {
+        var alphaPercent = (int)Math.Round(color.A * 100.0 / 255.0);
+        var effective = _backLogoBrightness * _backLogoOpacity * alphaPercent / 10000;
+        return Math.Clamp(effective, 0, 100);
+    }
+
+    private int GetBackLogoEffectDelayMs()
+    {
+        var normalized = Math.Clamp(_backLogoEffectSpeed, 1, 10);
+        return Math.Clamp(BackLogoMaxEffectDelayMs - normalized * 95, BackLogoMinEffectDelayMs, BackLogoMaxEffectDelayMs);
+    }
+
+    private void UpdateBackLogoEffectiveText(int? effectiveBrightness = null)
+    {
+        var color = _backLogoColorPicker?.Color ?? Color.Parse(DefaultBackLogoColor);
+        var effective = effectiveBrightness ?? GetEffectiveBackLogoBrightness(color);
+        var enabled = _backLogoEnabledCheckBox?.IsChecked ?? true;
+        var effect = _backLogoEffectComboBox?.SelectedIndex switch
+        {
+            1 => "Rainbow Cycle",
+            2 => "Breathing",
+            _ => "Static"
+        };
+
+        SetText(_backLogoEffectiveText, enabled
+            ? $"Effective output: {effect}, RGB #{ToRgbHex(color)}, intensity {effective}%"
+            : "Effective output: logo/lightbar disabled");
+    }
+
     private static string ToRgbHex(Color color)
     {
         return $"{color.R:X2}{color.G:X2}{color.B:X2}";
@@ -1052,6 +1370,47 @@ public partial class MainWindow : Window, INotifyPropertyChanged
             return false;
 
         return brightness is >= 0 and <= 100;
+    }
+
+
+    private static bool TryParseBackLogoColor(
+        string? value,
+        out string color,
+        out int brightness,
+        out bool enabled)
+    {
+        color = "FFFFFF";
+        brightness = 100;
+        enabled = true;
+
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        var parts = value.Trim().Split(',', StringSplitOptions.TrimEntries);
+
+        if (parts.Length < 2 || parts.Length > 3)
+            return false;
+
+        color = NormalizeRgbHex(parts[0]) ?? "";
+        if (color.Length != 6)
+            return false;
+
+        if (!int.TryParse(parts[1], out brightness) || brightness is < 0 or > 100)
+            return false;
+
+        if (parts.Length == 3)
+        {
+            if (!int.TryParse(parts[2], out var enableValue) || enableValue is < 0 or > 1)
+                return false;
+
+            enabled = enableValue == 1;
+        }
+        else
+        {
+            enabled = brightness > 0;
+        }
+
+        return true;
     }
 
     private static bool TryParseFourZoneMode(
@@ -1234,6 +1593,12 @@ public partial class MainWindow : Window, INotifyPropertyChanged
 
         if (_rightToLeftRadioButton != null)
             _rightToLeftRadioButton.IsChecked = direction == DirectionRightToLeft;
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        StopBackLogoEffect();
+        base.OnClosed(e);
     }
 
     public static class AppState

--- a/docs/PHN16-72-BACK-LOGO-INTEGRATION.md
+++ b/docs/PHN16-72-BACK-LOGO-INTEGRATION.md
@@ -1,0 +1,60 @@
+# PHN16-72 Back Logo / Lightbar Integration Notes
+
+## Root cause
+
+DAMX itself is a user-space GUI + daemon. The rear logo cannot be controlled unless the kernel driver exposes a sysfs node for it.
+
+The current DAMX package fetches `PXDiv/Div-Linuwu-Sense` at build/package time. The uploaded DAMX repository does not contain the driver source, so this DAMX patch only adds support for a future driver API.
+
+## Expected driver API
+
+Expose this sysfs file from the patched `linuwu_sense` driver:
+
+```text
+/sys/module/linuwu_sense/drivers/platform:acer-wmi/acer-wmi/back_logo/color
+```
+
+Read/write format:
+
+```text
+RRGGBB,brightness,enable
+```
+
+Example:
+
+```bash
+echo 'FFFFFF,100,1' | sudo tee /sys/module/linuwu_sense/drivers/platform:acer-wmi/acer-wmi/back_logo/color
+```
+
+## Driver-side work required
+
+Patch `PXDiv/Div-Linuwu-Sense`, not only DAMX:
+
+1. Add a capability flag such as `ACER_CAP_BACK_LOGO`.
+2. Add a `back_logo` quirk field and enable it for `Predator PHN16-72` / `EQE_RTX`.
+3. Add WMI methods for PHN16-72 logo/lightbar:
+   - WMID GUID: `7A4DDFE7-5B5D-40B4-8595-4408E0CC7F56`
+   - preferred set path: method/Arg1 `0x0C`
+   - preferred get path: method/Arg1 `0x0D`
+   - some firmware also gates power via `0x14` selector `2`, so a robust setter should drive both paths.
+4. Add a sysfs attribute group:
+   - group name: `back_logo`
+   - file: `color`
+   - write parser: `RRGGBB,brightness,enable`
+   - strict validation: RGB = 6 hex chars, brightness = 0..100, enable = 0/1.
+5. Register the `back_logo` group only when the capability is present.
+6. Keep existing `predator_sense` and `four_zoned_kb` groups unchanged so DAMX fan/profile/keyboard features keep working.
+
+## DAMX-side work included in this patch
+
+This repository patch adds:
+
+- daemon feature detection for `back_logo`
+- daemon command `set_back_logo_color`
+- daemon `get_all_settings` field `back_logo_color`
+- C# client method `SetBackLogoColorAsync`
+- GUI card under Keyboard Lighting: color, brightness, enable, apply
+
+## Important safety note
+
+Do not load two Acer WMI drivers at the same time. Patch and use one kernel module path: preferably `linuwu_sense` for DAMX compatibility.


### PR DESCRIPTION
## Summary

Adds safe, static rear back-logo/lightbar control to DAMX when the Linuwu-Sense driver advertises the `back_logo` capability.

The GUI exposes the hardware-backed controls supported by the driver: RGB color, brightness, enable/disable, and Apply.

Fixes #198.

## Changes

- Detects the driver-provided `back_logo/color` sysfs capability.
- Adds `back_logo` to daemon feature discovery and `back_logo_color` to `get_all_settings`.
- Adds the `set_back_logo_color` daemon command.
- Adds `DAMXClient.SetBackLogoColorAsync`.
- Adds a Back Logo / Lightbar card under Keyboard Lighting.
- Strictly validates RGB, brightness, and boolean enable values before any sysfs write.
- Preserves a useful GUI brightness when disabled firmware readback is normalized to `RRGGBB,0,0`.
- Limits this integration to static writes; continuous software effects were deliberately removed to avoid repeatedly invoking the firmware WMI setter.

## Driver dependency

Requires [PXDiv/Div-Linuwu-Sense#20](https://github.com/PXDiv/Div-Linuwu-Sense/pull/20), which exposes:

```text
/sys/module/linuwu_sense/drivers/platform:acer-wmi/acer-wmi/back_logo/color
```

Format:

```text
RRGGBB,brightness,enable
```

## Validation

Validated at commit `b8f9cb13d8b2b349a44dfd38fbc2e2d632eda805` on:

* Acer Predator PHN16-72 / EQE_RTX
* BIOS V1.16
* Omarchy
* Linux 7.1.9-arch1-2
* .NET SDK 9.0.120

### Results

* Python syntax check passed.
* Release build passed with 0 errors.
* Warning regression comparison: 95 baseline warning types, 95 PR warning types, 0 introduced by this PR.
* Strict daemon validation passed 10/10 valid and malformed-input cases.
* End-to-end socket -> daemon -> sysfs test passed.
* Invalid API input was rejected without changing hardware state.
* GUI successfully applied `#00FFCC` at 40% brightness.
* GUI disable state and physical logo-off state were verified.
* No relevant kernel faults or critical GUI runtime errors were logged.
* Original logo state and installed DAMX service were restored after testing.

## Safety

Only one Acer WMI driver should be loaded at a time. This integration was tested with the patched linuwu_sense module from the linked driver PR.
