### PR TITLE
fix: correct ENEK5130 zoom mapping and Nitro key setup

### DIFF
--- a/DAMM-Daemon/DAMX-Daemon.py
+++ b/DAMM-Daemon/DAMX-Daemon.py
@@ -654,8 +654,8 @@ class DAMXManager:
         5 Zoom, 6 Meteor, 7 Twinkling.
 
         Confirmed on Acer Nitro ANV16S-41 / ENEK5130:
-        0x04 breathing, 0x05 neon-like, 0x07 sliding,
-        0x09 wave, 0x0a snake/meteor-like, 0x0b random/twinkling-like.
+        0x04 breathing, 0x05 neon-like, 0x07 wave/shifting,
+        0x09 zoom, 0x0a snake/meteor-like, 0x0b random/twinkling-like.
 
         Unstable/unknown values are deliberately not mapped here:
         0x01/0x03 black/off, 0x06 short flash/returns to previous,
@@ -664,8 +664,9 @@ class DAMXManager:
         effect_map = {
             1: 0x04,  # Breathing Mode
             2: 0x05,  # Neon Mode
-            3: 0x09,  # Wave Mode
-            4: 0x07,  # Shifting Mode
+            3: 0x07,  # Wave Mode
+            4: 0x07,  # Shifting Mode (same confirmed native wave/shifting effect)
+            5: 0x09,  # Zoom Mode
             6: 0x0A,  # Meteor Mode (snake-like on ENEK5130)
             7: 0x0B,  # Twinkling Mode (random on ENEK5130)
         }

--- a/scripts/local-setup.sh
+++ b/scripts/local-setup.sh
@@ -374,21 +374,20 @@ EOL
 configure_nitro_button() {
   echo -e "${YELLOW}Configuring Nitro Button Hardware Code...${NC}"
 
-  # Ask user if they want to setup Nitro key with 10 second timeout
-  echo -e "${YELLOW}Do you want to Setup your Nitro Key? (Y/n) - Waiting 10 seconds...${NC}"
+  # Ask user if they want to setup Nitro key with 10 second timeout.
+  # Default to No so installs/updates do not silently add a keyboard hook service.
+  echo -e "${YELLOW}Do you want to setup your Nitro Key? (y/N) - Waiting 10 seconds...${NC}"
   read -t 10 -n 1 -r response
   
-  # Default to Yes if timeout or empty response
+  # Default to No if timeout or empty response
   if [[ $? -ne 0 ]] || [[ -z "$response" ]]; then
-    echo -e "\n${BLUE}No response detected. Proceeding with Nitro setup...${NC}"
-    response="Y"
+    echo -e "\n${BLUE}No response detected. Skipping Nitro button setup.${NC}"
+    response="N"
   fi
 
   # Check if user wants to skip
   if [[ ! "$response" =~ ^[Yy]$ ]]; then
-    echo -e "${BLUE}Skipping Nitro button configuration. Using default code (425).${NC}"
-    mkdir -p /etc/damx
-    echo "NITRO_KEY=425" > /etc/damx/nitro_key.conf
+    echo -e "${BLUE}Skipping Nitro button configuration. You can run setup again later to enable it.${NC}"
     return 0
   fi
 
@@ -425,6 +424,24 @@ configure_nitro_button() {
   install_nitro_service
 }
 
+detect_desktop_user() {
+  if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ] && id -u "$SUDO_USER" >/dev/null 2>&1; then
+    echo "$SUDO_USER"
+    return 0
+  fi
+
+  if command -v loginctl >/dev/null 2>&1; then
+    local session_user
+    session_user=$(loginctl list-sessions --no-legend 2>/dev/null | awk '$3 != "root" && $3 != "gdm" { print $3; exit }')
+    if [ -n "$session_user" ] && id -u "$session_user" >/dev/null 2>&1; then
+      echo "$session_user"
+      return 0
+    fi
+  fi
+
+  awk -F: '$3 >= 1000 && $3 < 60000 && $1 != "nobody" { print $1; exit }' /etc/passwd
+}
+
 install_nitro_service() {
   echo -e "${YELLOW}Installing Nitro Key Detection Service...${NC}"
   
@@ -434,6 +451,14 @@ install_nitro_service() {
   # Get the directory where the main script is located
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   NITRO_SCRIPT="$SCRIPT_DIR/nitro-key-detection.sh"
+  TARGET_USER=$(detect_desktop_user)
+
+  if [ -z "$TARGET_USER" ] || ! id -u "$TARGET_USER" >/dev/null 2>&1; then
+    echo -e "${RED}Error: Could not determine desktop user for Nitro key launcher.${NC}"
+    return 1
+  fi
+
+  echo -e "${BLUE}Nitro key will launch DAMX for user: ${TARGET_USER}${NC}"
   
   # Check if NitroKeyDetection.sh exists
   if [ ! -f "$NITRO_SCRIPT" ]; then
@@ -463,6 +488,7 @@ RestartSec=10
 StandardOutput=journal
 StandardError=journal
 User=root
+Environment=DAMX_TARGET_USER=${TARGET_USER}
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/nitro-key-detection.sh
+++ b/scripts/nitro-key-detection.sh
@@ -1,10 +1,31 @@
 #!/bin/bash
+set -euo pipefail
 
 if [ -f "/etc/damx/nitro_key.conf" ]; then
+    # shellcheck disable=SC1091
     source /etc/damx/nitro_key.conf
 else
     NITRO_KEY=425
 fi
+
+find_target_user() {
+    if [ -n "${DAMX_TARGET_USER:-}" ] && id -u "$DAMX_TARGET_USER" >/dev/null 2>&1; then
+        echo "$DAMX_TARGET_USER"
+        return 0
+    fi
+
+    if [ -n "${SUDO_USER:-}" ] && [ "$SUDO_USER" != "root" ] && id -u "$SUDO_USER" >/dev/null 2>&1; then
+        echo "$SUDO_USER"
+        return 0
+    fi
+
+    if command -v loginctl >/dev/null 2>&1; then
+        loginctl list-sessions --no-legend 2>/dev/null | awk '$3 != "root" && $3 != "gdm" { print $3; exit }'
+        return 0
+    fi
+
+    awk -F: '$3 >= 1000 && $3 < 60000 && $1 != "nobody" { print $1; exit }' /etc/passwd
+}
 
 DEVICE=$(grep -A 5 -B 5 "AT Translated Set 2 keyboard" /proc/bus/input/devices | grep -m 1 "event" | sed 's/.*event\([0-9]\+\).*/\/dev\/input\/event\1/')
 
@@ -13,33 +34,52 @@ if [ -z "$DEVICE" ]; then
     exit 1
 fi
 
-echo "Monitoring Nitro button (code $NITRO_KEY) on $DEVICE..."
+if ! command -v evtest >/dev/null 2>&1; then
+    echo "Error: evtest is required for Nitro key detection. Re-run setup or install evtest."
+    exit 1
+fi
 
-TARGET_USER="div"
+TARGET_USER=$(find_target_user)
+if [ -z "$TARGET_USER" ] || ! id -u "$TARGET_USER" >/dev/null 2>&1; then
+    echo "Error: could not determine target desktop user for launching DAMX."
+    exit 1
+fi
+
 USER_ID=$(id -u "$TARGET_USER")
 
 DISPLAY=""
 XAUTHORITY=""
+WAYLAND_DISPLAY=""
 
-# Wait (up to 60s) for a div-owned process with a valid DISPLAY+XAUTHORITY
-for i in $(seq 1 60); do
-    for pid in $(pgrep -u "$TARGET_USER"); do
+# Wait (up to 60s) for a target-user process with useful graphical session env.
+for _ in $(seq 1 60); do
+    while IFS= read -r pid; do
         if [ -r "/proc/$pid/environ" ]; then
-            ENV_DISPLAY=$(tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null | grep '^DISPLAY=' | cut -d= -f2-)
-            ENV_XAUTH=$(tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null | grep '^XAUTHORITY=' | cut -d= -f2-)
-            if [ -n "$ENV_DISPLAY" ] && [ -n "$ENV_XAUTH" ] && [ -f "$ENV_XAUTH" ]; then
+            ENV_DISPLAY=$(tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null | grep '^DISPLAY=' | cut -d= -f2- || true)
+            ENV_WAYLAND=$(tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null | grep '^WAYLAND_DISPLAY=' | cut -d= -f2- || true)
+            ENV_XAUTH=$(tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null | grep '^XAUTHORITY=' | cut -d= -f2- || true)
+
+            if [ -n "$ENV_DISPLAY" ]; then
                 DISPLAY="$ENV_DISPLAY"
+            fi
+            if [ -n "$ENV_WAYLAND" ]; then
+                WAYLAND_DISPLAY="$ENV_WAYLAND"
+            fi
+            if [ -n "$ENV_XAUTH" ] && [ -f "$ENV_XAUTH" ]; then
                 XAUTHORITY="$ENV_XAUTH"
+            fi
+
+            if [ -n "$DISPLAY" ] || [ -n "$WAYLAND_DISPLAY" ]; then
                 break 2
             fi
         fi
-    done
+    done < <(pgrep -u "$TARGET_USER" || true)
     sleep 1
 done
 
-# If no XAUTHORITY var was found in environ, fall back to common locations
+# If no XAUTHORITY var was found in environ, fall back to common locations.
 if [ -z "$XAUTHORITY" ]; then
-    for candidate in "/run/user/$USER_ID/gdm/Xauthority" "/home/$TARGET_USER/.Xauthority"; do
+    for candidate in "/run/user/$USER_ID/gdm/Xauthority" "/home/$TARGET_USER/.Xauthority" /run/user/$USER_ID/.mutter-Xwaylandauth.*; do
         if [ -f "$candidate" ]; then
             XAUTHORITY="$candidate"
             break
@@ -48,20 +88,30 @@ if [ -z "$XAUTHORITY" ]; then
 fi
 
 : "${DISPLAY:=:0}"
+: "${WAYLAND_DISPLAY:=wayland-0}"
 
 if [ -z "$XAUTHORITY" ] || [ ! -f "$XAUTHORITY" ]; then
     echo "Warning: could not find a valid XAUTHORITY file."
 fi
 
 export DISPLAY
+export WAYLAND_DISPLAY
 export XAUTHORITY
+export XDG_RUNTIME_DIR="/run/user/$USER_ID"
 export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$USER_ID/bus"
 
-echo "Using DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY"
+echo "Monitoring Nitro button (code $NITRO_KEY) on $DEVICE for user $TARGET_USER..."
+echo "Using DISPLAY=$DISPLAY WAYLAND_DISPLAY=$WAYLAND_DISPLAY XAUTHORITY=$XAUTHORITY"
 
-sudo evtest "$DEVICE" | grep --line-buffered "code $NITRO_KEY.*value 1" | while read -r line; do
+evtest "$DEVICE" | grep --line-buffered "code $NITRO_KEY.*value 1" | while read -r _line; do
     if ! pgrep -f "/opt/damx/gui/DivAcerManagerMax" > /dev/null; then
-        sudo -u "$TARGET_USER" DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" DAMX &
+        sudo -u "$TARGET_USER" \
+            DISPLAY="$DISPLAY" \
+            WAYLAND_DISPLAY="$WAYLAND_DISPLAY" \
+            XAUTHORITY="$XAUTHORITY" \
+            XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
+            DBUS_SESSION_BUS_ADDRESS="$DBUS_SESSION_BUS_ADDRESS" \
+            DAMX &
     else
         echo "Interface is already running!"
     fi


### PR DESCRIPTION
## Summary

This is a small follow-up after testing the merged ENEK5130 work on Nitro ANV16S-41.

It fixes two things:

1. Corrects the ENEK5130 native effect mapping for `Wave` / `Zoom`.
2. Fixes Nitro key setup so it does not install silently with a hardcoded desktop user.

## ENEK5130 RGB mode correction

This part is my bad: during the first PR I mistakenly named one of the native RGB keyboard modes incorrectly.

After retesting `0x07` vs `0x09` on Nitro ANV16S-41 and comparing with the PHN16S-71 data from @shwetankg07, the corrected mapping is:

```text
0x07 -> wave / shifting
0x09 -> zoom
```

Retest result on Nitro ANV16S-41:

```text
0x07 speed=5 direction=1 -> wave from left to right
0x07 speed=1 direction=1 -> same wave, slower
0x07 speed=10 direction=1 -> same wave, faster
0x07 speed=5 direction=2 -> wave from right to left

0x09 speed=5 direction=1 -> zoom
0x09 speed=1 direction=1 -> zoom, slower
0x09 speed=10 direction=1 -> zoom, faster
0x09 speed=5 direction=2 -> same zoom; direction appears ignored
```

So this PR changes the DAMX mapping to:

```text
DAMX Wave Mode    -> HID 0x07
DAMX Shifting Mode -> HID 0x07
DAMX Zoom Mode    -> HID 0x09
```

`Shifting` still maps to `0x07` because the confirmed native effect is the closest safe match currently known for that slot.

## Nitro key setup fix

While testing the new release, the Nitro key service installed successfully but did not launch DAMX correctly.

The cause was in `scripts/nitro-key-detection.sh`:

```bash
TARGET_USER="div"
```

That meant every install tried to launch DAMX as user `div`. On normal user systems, that user does not exist, so the service logs errors like:

```text
id: 'div': no such user
pgrep: invalid user name: div
```

There was also an installer behavior issue: the prompt defaulted to `Y` after timeout:

```text
Do you want to Setup your Nitro Key? (Y/n)
```

So updates could silently install a keyboard hook service even if the user did not explicitly choose it.

## What changed

### `scripts/local-setup.sh`

- Changed Nitro key setup prompt from default yes to default no:

```text
Do you want to setup your Nitro Key? (y/N)
```

- Added desktop-user detection:

```text
1. SUDO_USER
2. active loginctl desktop session
3. first normal UID >= 1000 fallback
```

- Writes the detected user into the systemd unit:

```ini
Environment=DAMX_TARGET_USER=<detected-user>
```

### `scripts/nitro-key-detection.sh`

- Removed the hardcoded `TARGET_USER="div"`.
- Uses `DAMX_TARGET_USER` when provided by systemd.
- Falls back to `SUDO_USER`, `loginctl`, or a normal local user.
- Adds a clear `evtest` dependency error instead of failing later.
- Exports `XDG_RUNTIME_DIR`, `DBUS_SESSION_BUS_ADDRESS`, `WAYLAND_DISPLAY`, `DISPLAY`, and `XAUTHORITY` for launching the GUI in the user's session.
- Stops calling `sudo evtest` from inside a root service; it just runs `evtest` directly.

## Local verification

Ran successfully:

```bash
bash -n scripts/nitro-key-detection.sh scripts/local-setup.sh
python3 -m py_compile DAMM-Daemon/DAMX-Daemon.py DAMM-Daemon/KeyboardMonitor.py DAMM-Daemon/PowerSourceDetection.py
git diff --check
```

Also tested locally on Nitro ANV16S-41 with a fixed service: pressing the NitroSense key detected key code `425` and launched DAMX as the correct user instead of trying to use `div`.
