### PR TITLE
feat: extend the Nitro key setup to Predator machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ If the remote installation fails for some reason or you've gone offline, follow 
 
 ✅ That’s it—you’re all set!
 
+## 🔘 Nitro / PredatorSense Button
+
+During setup you can bind your laptop's dedicated button (the **N** key on
+Nitros, the **PredatorSense** key on Predators) to open DAMX. Both are the
+same button as far as the EC is concerned — it sends scancode `0xf5`, which
+the kernel maps to keycode `425` on most models. Some models carry a udev
+hwdb quirk that remaps it to `prog1` (`148`) instead, which is why setup
+captures the code from an actual press rather than assuming one.
+
+Confirmed so far: Nitro ANV16S-41, Predator PHN16S-71 (both `425`).
+
+**Note for keyd/kmonad users:** key remappers grab the keyboard exclusively,
+so the detection service never sees the button. Bind the key in the
+remapper's config instead (after keyd it typically surfaces as `f16` /
+`XF86Launch7`).
+
 ## 🖥️ Troubleshooting
 
 You can check the logs at /var/log/DAMX_Daemon_Log.log

--- a/scripts/local-setup.sh
+++ b/scripts/local-setup.sh
@@ -372,11 +372,13 @@ EOL
 }
 
 configure_nitro_button() {
-  echo -e "${YELLOW}Configuring Nitro Button Hardware Code...${NC}"
+  echo -e "${YELLOW}Configuring Nitro/PredatorSense Button Hardware Code...${NC}"
 
-  # Ask user if they want to setup Nitro key with 10 second timeout.
+  # Ask user if they want to setup the key with 10 second timeout.
   # Default to No so installs/updates do not silently add a keyboard hook service.
-  echo -e "${YELLOW}Do you want to setup your Nitro Key? (y/N) - Waiting 10 seconds...${NC}"
+  # Predator machines have the same dedicated button (the PredatorSense key) —
+  # it even sends the same code as the Nitro key on the models tested so far.
+  echo -e "${YELLOW}Do you want to setup your Nitro/PredatorSense Key? (y/N) - Waiting 10 seconds...${NC}"
   read -t 10 -n 1 -r response
   
   # Default to No if timeout or empty response
@@ -387,13 +389,22 @@ configure_nitro_button() {
 
   # Check if user wants to skip
   if [[ ! "$response" =~ ^[Yy]$ ]]; then
-    echo -e "${BLUE}Skipping Nitro button configuration. You can run setup again later to enable it.${NC}"
+    echo -e "${BLUE}Skipping button configuration. You can run setup again later to enable it.${NC}"
     return 0
   fi
 
   if ! command -v evtest &> /dev/null; then
     echo -e "${BLUE}Installing evtest for hardware detection...${NC}"
-    apt-get update && apt-get install -y evtest
+    if command -v apt-get &> /dev/null; then
+      apt-get update && apt-get install -y evtest
+    elif command -v dnf &> /dev/null; then
+      dnf install -y evtest
+    elif command -v pacman &> /dev/null; then
+      pacman -S --noconfirm --needed evtest
+    else
+      echo -e "${RED}Could not install evtest automatically. Install it with your package manager and re-run setup.${NC}"
+      return 1
+    fi
   fi
 
   DEVICE=$(grep -A 5 -B 5 "AT Translated Set 2 keyboard" /proc/bus/input/devices | grep -m 1 "event" | sed 's/.*event\([0-9]\+\).*/\/dev\/input\/event\1/')
@@ -407,16 +418,22 @@ configure_nitro_button() {
   fi
 
   echo -e "${GREEN}Keyboard detected at: $DEVICE${NC}"
-  echo -e "${YELLOW}>>> PLEASE PRESS YOUR NITRO (N) BUTTON NOW (Waiting 30 seconds)... <<<${NC}"
+  echo -e "${YELLOW}>>> PLEASE PRESS YOUR NITRO / PREDATORSENSE BUTTON NOW (Waiting 30 seconds)... <<<${NC}"
 
-  # NitroButton code 
+  # On both Nitro and Predator EC keyboards the button arrives as scancode
+  # 0xf5, which the kernel maps to keycode 425 unless an hwdb quirk remaps
+  # it (some models get prog1/148). Capturing beats hardcoding either one.
   CAPTURED_CODE=$(timeout 30 evtest "$DEVICE" | grep -m 1 "type 1 (EV_KEY).*value 1" | sed -n 's/.*code \([0-9]*\).*/\1/p')
 
   if [ -n "$CAPTURED_CODE" ]; then
-    echo -e "${GREEN}Success! Nitro button code captured: ${CAPTURED_CODE}${NC}"
+    echo -e "${GREEN}Success! Button code captured: ${CAPTURED_CODE}${NC}"
     echo "NITRO_KEY=$CAPTURED_CODE" > /etc/damx/nitro_key.conf
   else
     echo -e "${RED}Timeout or no key detected. Falling back to default code (425).${NC}"
+    echo -e "${YELLOW}If you DID press the button: key remappers like keyd or kmonad grab the${NC}"
+    echo -e "${YELLOW}keyboard exclusively, so this capture (and the detection service) never${NC}"
+    echo -e "${YELLOW}sees the key. Stop the remapper and re-run setup, or bind the key in the${NC}"
+    echo -e "${YELLOW}remapper's own config instead.${NC}"
     echo "NITRO_KEY=425" > /etc/damx/nitro_key.conf
   fi
   
@@ -458,7 +475,7 @@ install_nitro_service() {
     return 1
   fi
 
-  echo -e "${BLUE}Nitro key will launch DAMX for user: ${TARGET_USER}${NC}"
+  echo -e "${BLUE}The button will launch DAMX for user: ${TARGET_USER}${NC}"
   
   # Check if NitroKeyDetection.sh exists
   if [ ! -f "$NITRO_SCRIPT" ]; then
@@ -476,7 +493,7 @@ install_nitro_service() {
   # Create systemd service file
   cat > /etc/systemd/system/nitro-key-detection.service << EOF
 [Unit]
-Description=Nitro Key Detection Service
+Description=Nitro/PredatorSense Key Detection Service
 After=multi-user.target
 After=network.target
 

--- a/scripts/nitro-key-detection.sh
+++ b/scripts/nitro-key-detection.sh
@@ -100,7 +100,7 @@ export XAUTHORITY
 export XDG_RUNTIME_DIR="/run/user/$USER_ID"
 export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$USER_ID/bus"
 
-echo "Monitoring Nitro button (code $NITRO_KEY) on $DEVICE for user $TARGET_USER..."
+echo "Monitoring Nitro/PredatorSense button (code $NITRO_KEY) on $DEVICE for user $TARGET_USER..."
 echo "Using DISPLAY=$DISPLAY WAYLAND_DISPLAY=$WAYLAND_DISPLAY XAUTHORITY=$XAUTHORITY"
 
 evtest "$DEVICE" | grep --line-buffered "code $NITRO_KEY.*value 1" | while read -r _line; do


### PR DESCRIPTION
## Summary

The Nitro key feature already works on Predator machines — nobody can tell, because every prompt says "Nitro". While verifying that on my PHN16S-71 I also hit two real traps that would stop a Predator (or any non-Debian) user from ever getting the feature running. This PR fixes the naming and both traps. Rebased onto #219 (now merged), since it reworked the same scripts.

## Why the feature already works

The PredatorSense key is electrically the same button as the Nitro key. Captured on my PHN16S-71 with keyd stopped:

```
scancode 0xf5 on AT Translated Set 2 keyboard (/dev/input/event2)
key code 425 on AT Translated Set 2 keyboard (/dev/input/event2)
```

Same scancode, same keycode 425 the setup uses as default, same device the script greps for. @abduvaliy-hbai's ANV16S-41 matches. One caveat keeps the interactive capture necessary: some models have a udev hwdb quirk (systemd `60-keyboard.hwdb`) remapping `0xf5` to `prog1`/148 — e.g. the PHN16-71 (non-S) and Nitro AN515-47 — so the code isn't universal and capturing a real press stays the right call.

## The two traps

1. **evtest install is apt-get only.** On Fedora/Arch the setup step just dies before the capture can happen. Now tries `apt-get`/`dnf`/`pacman` and says so if none match.

2. **Key remappers silently kill the feature.** keyd/kmonad grab the keyboard exclusively (EVIOCGRAB), so the capture times out and the detection service never sees the button — no error anywhere. Found this on my own machine: with keyd running the button comes out the other side renamed as `f16` (code 186) on keyd's virtual keyboard, so even the stored 425 wouldn't match. The timeout message now explains what's happening and what to do (bind the key in the remapper instead, or stop it during setup).

## Changes

- User-facing strings say "Nitro/PredatorSense" — service, script and config file names are untouched, so uninstall/cleanup paths are unaffected
- Distro-aware evtest install
- Remapper explanation on capture timeout
- README section documenting the button: scancode/keycode identity, hwdb caveat, remapper note, confirmed models

## Testing

- Verified the key identity on PHN16S-71 (evdev capture above, repeated with keyd running to confirm the grab/rename behavior)
- `bash -n` clean on both scripts
- Haven't run the full setup flow end-to-end here (my machine already runs a manually configured DAMX stack) — the changed lines are prompts, the package-manager branch, and the timeout message, all inert to the capture logic itself

@abduvaliy-hbai you reworked these scripts in #219 — review suggestions very welcome, especially on the wording. And if you get a chance to re-run setup on the ANV16S-41 to confirm nothing regressed on the Nitro side, that would cover both families.
