### PR TITLE
fix: restore LLVM kernel support in packaged installer

### DIFF
--- a/.github/workflows/workflow2.yml
+++ b/.github/workflows/workflow2.yml
@@ -174,14 +174,8 @@ jobs:
         elif [ -f "scripts/local-setup.sh" ]; then
           cp "scripts/local-setup.sh" "${{ env.package_dir }}/setup.sh"
         else
-          echo "Warning: local-setup.sh not found, creating a basic one"
-          cat > "${{ env.package_dir }}/setup.sh" << 'EOF'
-        #!/bin/bash
-        # DAMX Installation Script
-        echo "DAMX Installation"
-        echo "=================="
-        echo "Please run the installation manually or provide a proper setup.sh script"
-        EOF
+          echo "Error: local-setup.sh not found"
+          exit 1
         fi
         
         # Update version information in setup script
@@ -200,6 +194,18 @@ jobs:
         else
           echo "Warning: nitro-key-detection.sh not found, skipping"
         fi
+
+    - name: Validate Packaged Installer
+      run: |
+        SETUP_SCRIPT="${{ env.package_dir }}/setup.sh"
+        bash -n "$SETUP_SCRIPT"
+
+        if ! grep -Eq '^is_llvm_kernel\(\)[[:space:]]*\{' "$SETUP_SCRIPT"; then
+          echo "Error: setup.sh is missing is_llvm_kernel()"
+          exit 1
+        fi
+
+        echo "✓ Packaged installer validation passed"
     
     - name: Create Release Information
       run: |

--- a/scripts/local-setup.sh
+++ b/scripts/local-setup.sh
@@ -212,6 +212,45 @@ cleanup_nitro_service() {
   echo -e "${GREEN}Nitro Key Detection Service cleanup completed.${NC}"
 }
 
+# Detect the compiler used to build the running kernel.
+is_llvm_kernel() {
+  local kernel_release
+  local kernel_build
+  local config_file
+
+  kernel_release=$(uname -r)
+  kernel_build="/lib/modules/${kernel_release}/build"
+
+  for config_file in "/boot/config-${kernel_release}" "${kernel_build}/.config"; do
+    if [ -r "$config_file" ] && grep -q '^CONFIG_CC_IS_CLANG=y' "$config_file"; then
+      return 0
+    fi
+  done
+
+  if command -v zgrep &> /dev/null &&
+     [ -r /proc/config.gz ] &&
+     zgrep -q '^CONFIG_CC_IS_CLANG=y' /proc/config.gz; then
+    return 0
+  fi
+
+  if grep -qsiE 'clang|llvm' /proc/version 2>/dev/null; then
+    return 0
+  fi
+
+  if [ -r "${kernel_build}/include/generated/compile.h" ] &&
+     grep -qsiE 'clang|llvm' "${kernel_build}/include/generated/compile.h"; then
+    return 0
+  fi
+
+  # CachyOS kernels are LLVM-built by default. Keep this fallback for
+  # installations where the running kernel does not expose its build config.
+  if [ -r /etc/os-release ] && grep -qi 'cachyos' /etc/os-release; then
+    return 0
+  fi
+
+  return 1
+}
+
 # Install build dependencies based on distribution
 install_build_deps() {
   if command -v pacman &> /dev/null; then
@@ -230,6 +269,8 @@ install_build_deps() {
 }
 
 install_drivers() {
+  local build_args=()
+
   echo -e "${YELLOW}Installing Linuwu-Sense drivers...${NC}"
 
   if [ ! -d "Linuwu-Sense" ]; then
@@ -244,33 +285,41 @@ install_drivers() {
   # Install required build dependencies
   if ! command -v make &> /dev/null; then
     echo -e "${YELLOW}Installing build tools...${NC}"
-    install_build_deps
+    install_build_deps || {
+      cd ..
+      return 1
+    }
   fi
 
   # Build driver with appropriate compiler flags
-  # LLVM-compiled kernels (CachyOS, etc.) require matching compiler
   if is_llvm_kernel; then
     echo -e "${YELLOW}Detected LLVM-compiled kernel, using Clang...${NC}"
-    install_build_deps  # Ensure clang is installed
-    make clean LLVM=1 CC=clang
-    make LLVM=1 CC=clang
-    make install LLVM=1 CC=clang
-  else
-    make clean
-    make
-    make install
+    if ! command -v clang &> /dev/null; then
+      install_build_deps || {
+        cd ..
+        return 1
+      }
+    fi
+    build_args=(LLVM=1 CC=clang)
   fi
 
-  if [ $? -eq 0 ]; then
-    echo -e "${GREEN}Linuwu-Sense drivers installed successfully!${NC}"
+  if ! make clean "${build_args[@]}" || ! make "${build_args[@]}"; then
+    echo -e "${RED}Error: Failed to build Linuwu-Sense drivers${NC}"
     cd ..
-    return 0
-  else
+    pause
+    return 1
+  fi
+
+  if ! make install "${build_args[@]}"; then
     echo -e "${RED}Error: Failed to install Linuwu-Sense drivers${NC}"
     cd ..
     pause
     return 1
   fi
+
+  echo -e "${GREEN}Linuwu-Sense drivers installed successfully!${NC}"
+  cd ..
+  return 0
 }
 
 install_daemon() {
@@ -558,6 +607,10 @@ perform_install() {
   if [ "$skip_drivers" = false ]; then
     install_drivers
     DRIVER_RESULT=$?
+    if [ $DRIVER_RESULT -ne 0 ]; then
+      echo -e "${RED}Driver installation failed; daemon and GUI installation were not attempted.${NC}"
+      return $DRIVER_RESULT
+    fi
   else
     echo -e "${YELLOW}Skipping driver installation as requested.${NC}"
     DRIVER_RESULT=0


### PR DESCRIPTION
## What happened

This fixes the CachyOS installation failure reported in #224.

The LLVM kernel support added in #141 was working correctly, but a later change
accidentally removed the `is_llvm_kernel()` function while leaving its calls in
`setup.sh`. Because of that, the installer printed:

`is_llvm_kernel: command not found`

It then tried to compile the driver with GCC. CachyOS kernels are built with
Clang, so GCC could not understand some of the kernel's compiler flags and the
driver installation failed.

## What this changes

- Restores `is_llvm_kernel()`.
- Detects Clang-built kernels using the kernel configuration and compiler
  information, with a CachyOS fallback.
- Uses `LLVM=1 CC=clang` when the running kernel was built with LLVM.
- Installs the Clang build dependencies when needed.
- Stops the installation if the driver fails to build or install instead of
  continuing with a partially working DAMX installation.
- Adds a release workflow check so a packaged `setup.sh` cannot silently ship
  without `is_llvm_kernel()` again.

## Testing

I tested this using the Linuwu-Sense source included in DAMX v1.0.2. It builds
successfully with Clang 22 against the CachyOS 7.1.3-2 kernel headers.

I also checked that:

- CachyOS selects the LLVM/Clang build path.
- A normal Arch/GCC environment still uses the default build path.
- `make install` is not called if compilation fails.
- The daemon and GUI are not installed after a driver failure.
- The packaged installer passes `bash -n`.
- The workflow YAML and Git diff checks pass.

This PR only addresses the LLVM compiler regression reported in #224.

The Secure Boot problem reported in #223 is a larger, separate issue involving
module signing and installation behavior. It needs more investigation and
testing across different distributions and Secure Boot configurations before a
reliable fix can be submitted, so it is intentionally not included in this PR.

Fixes #224.
